### PR TITLE
chore: apply override in kind service

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ proxy:
   read_timeout: 10000000
   retries: 10
   write_timeout: 10000000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    konghq.com/override: kong-timeout-conf
 ```
 
 [kong ingress controller documentation]: https://docs.konghq.com/gateway/1.1.x/reference/proxy/#3-proxying-and-upstream-timeouts


### PR DESCRIPTION
Adding `konghq.com/override` annotation at the kind Service.

cause https://github.com/ratsclub/medium-tcp-broken-pipe/pull/1 was closed :trollface: 